### PR TITLE
Simplify compression logic

### DIFF
--- a/src/tornado/compression.cljc
+++ b/src/tornado/compression.cljc
@@ -1,57 +1,21 @@
 (ns tornado.compression
   "A namespace for compression of the compiled CSS file."
-  (:require [clojure.string :as str]))
+  (:require
+   [clojure.string :as str]))
 
-;; Yes, I am lazy, and I did not care about this namespace at all. Right now, it is not
-;; my priority to write better RegExps. Maybe I will improve this namespace later.
 
-(defn ^String compress-newlines
-  "Transforms newlines to spaces."
-  [^String expr]
-  (str/replace expr #"\n+" " "))
+(defn compress-whitespace
+  ^String [expr]
+  (str/replace expr #"\s+" " "))
 
-(defn ^String reduce-spaces
-  "Reduces consecutive spaces to one space."
-  [^String expr]
-  (str/replace expr #"\ +" " "))
+(defn strip-whitespace-around
+  "Remove whitespace before and after these characters: `,;:{}[]()`."
+  ^String [expr]
+  (str/replace expr #"\s*([,;:{}\[\]\(\)])\s*" "$1"))
 
-(defn ^String remove-spaces-after-commas
-  "Removes spaces directly after commas."
-  [^String expr]
-  (str/replace expr #"\, " ","))
-
-(defn ^String remove-spaces-after-semicolons
-  "Removes spaces directly after semicolons."
-  [^String expr]
-  (str/replace expr #"\; " ";"))
-
-(defn ^String remove-spaces-after-colons
-  "Removes spaces directly after colons."
-  [^String expr]
-  (str/replace expr #"\: " ":"))
-
-(defn ^String remove-spaces-around-brackets
-  "Removes spaces before and after all types of brackets."
-  [^String expr]
-  (-> expr (str/replace #"\{ " "{")
-      (str/replace #" \{" "{")
-      (str/replace #"\} " "}")
-      (str/replace #" \}" "}")
-      (str/replace #"\[ " "[")
-      (str/replace #" \[" "[")
-      (str/replace #"\] " "]")
-      (str/replace #" \]" "]")
-      (str/replace #"\( " "(")
-      (str/replace #" \(" "(")
-      (str/replace #"\) " ")")
-      (str/replace #" \)" ")")))
-
-(defn ^String compress
-  "Compresses a stylesheet."
-  [^String expr]
-  (-> expr compress-newlines
-      reduce-spaces
-      remove-spaces-after-commas
-      remove-spaces-after-semicolons
-      remove-spaces-after-colons
-      remove-spaces-around-brackets))
+(defn compress
+  "Compress a stylesheet by removing any extra whitespace."
+  ^String [expr]
+  (-> expr
+      compress-whitespace
+      strip-whitespace-around))

--- a/src/tornado/compression.cljc
+++ b/src/tornado/compression.cljc
@@ -15,7 +15,7 @@
 
 (defn compress
   "Compress a stylesheet by removing any extra whitespace."
-  ^String [expr]
+  ^String [^String expr]
   (-> expr
       compress-whitespace
       strip-whitespace-around))

--- a/src/tornado/compression.cljc
+++ b/src/tornado/compression.cljc
@@ -1,7 +1,6 @@
 (ns tornado.compression
   "A namespace for compression of the compiled CSS file."
-  (:require
-   [clojure.string :as str]))
+  (:require [clojure.string :as str]))
 
 
 (defn compress-whitespace

--- a/test/tornado/test/compression.clj
+++ b/test/tornado/test/compression.clj
@@ -1,0 +1,18 @@
+(ns tornado.test.compression
+  (:require [clojure.test :refer :all]
+            [tornado.compression :as compression]))
+
+(deftest compress-whitespace
+  (is (= " a b c "
+         (compression/compress-whitespace"   a   \n b c   "))))
+
+(deftest strip-whitespace-around
+  (is (= "[]{};,:()"
+         (compression/strip-whitespace-around " [ ] { } ; , : ( ) "))))
+
+(deftest compress
+  (is (= "div{border-color:rgb(255,255,255);}"
+       (compression/compress
+           "div {
+                border-color: rgb( 255, 255, 255);
+            }"))))

--- a/test/tornado/test/compression.clj
+++ b/test/tornado/test/compression.clj
@@ -12,7 +12,7 @@
 
 (deftest compress
   (is (= "div{border-color:rgb(255,255,255);}"
-       (compression/compress
-           "div {
-                border-color: rgb( 255, 255, 255);
-            }"))))
+         (compression/compress
+          "div {
+               border-color: rgb( 255, 255, 255);
+           }"))))

--- a/test/tornado/test/compression.clj
+++ b/test/tornado/test/compression.clj
@@ -4,7 +4,7 @@
 
 (deftest compress-whitespace
   (is (= " a b c "
-         (compression/compress-whitespace"   a   \n b c   "))))
+         (compression/compress-whitespace "   a   \n b c   "))))
 
 (deftest strip-whitespace-around
   (is (= "[]{};,:()"


### PR DESCRIPTION
I made some changes to simplify the compression logic down to 2 regular expressions. The first one to compact all whitespace (`\s`) and the second one to strip whitespace around all characters that need it.  Also added some basic unit tests but more complex test cases might need to be added later on. All in all, it should behave exactly like the previous code, no changes in the logic.